### PR TITLE
[Hot fix] 인증서 생성기 누락 추가

### DIFF
--- a/frontend/issuer.yaml
+++ b/frontend/issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+  namespace: default
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: 05-project@narumir.io
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
- 인증서 생성할 letsencrypt가 cd 대상 디렉토리에서 누락되어 있어서 추가